### PR TITLE
Fix `obj-convert` test

### DIFF
--- a/test/clojure/com/interrupt/edgar/obj_convert_test.clj
+++ b/test/clojure/com/interrupt/edgar/obj_convert_test.clj
@@ -9,6 +9,8 @@
   (let [obj (Object.)]
     (is (identical? obj (sut/convert obj)))))
 
+(deftype TestType [f1 f2 f3])
+
 (deftest to-map-test
-  (is (= {:f1 1 :f2 2 :f3 3}
-         (sut/to-map (->TestType 1 2 3)))))
+  (is (= {:f1 1 :f2 2 :f3 3} (sut/to-map (->TestType 1 2 3))))
+  (is (= {:f1 1 :f2 2} (sut/to-map (->TestType 1 2 nil)))))


### PR DESCRIPTION
Let's set up CircleCI so we can keep check-ins in good condition.